### PR TITLE
Fix #15: Fixes parsing the output for rpm verify test

### DIFF
--- a/Introspection/rpm_verify_tests.py
+++ b/Introspection/rpm_verify_tests.py
@@ -73,9 +73,12 @@ class RPMVerifyTest(object):
             if line.startswith("error:"):
                 continue
             match = re.search(r'^([0-9A-Za-z.]+)\s+([c]{0,1})\s+(\W.*)$', line)
-            if match is None:
-              return "error"
 
+            # filter the lines with warnings or errors
+            if not match:
+                continue
+
+            # filter the config files
             if match.groups()[1] == 'c':
                 continue
 
@@ -83,7 +86,6 @@ class RPMVerifyTest(object):
             rpm = self.source_rpm_of_file(filepath)
             rpm_meta = self.get_meta_of_rpm(rpm)
             # do not include the config files in the result
-
 
             result.append({
               "issue": match.groups()[0],


### PR DESCRIPTION
  Fixes #15

  rpm verify test uses `rpm -Va` command to enlist the tampered files
  in system. `rpm -Va` also enlists other issues. For example:

```
  ✗ docker run -ti docker.io/centos/postgresql bash
  bash-4.2# rpm -Va
  Unsatisfied dependencies for fakesystemd-1-16.el7.centos.noarch:
  systemd conflicts with (installed) fakesystemd-1-16.el7.centos.noarch
  [..]
```

  The regex written to parse the output of `rpm -Va` output was failing to
  parse the output if such warnings will come in the output. This commit
  fixes the issue.
